### PR TITLE
Adds a prop to force split the dimension headers

### DIFF
--- a/src/components/PivotDataTable.vue
+++ b/src/components/PivotDataTable.vue
@@ -275,6 +275,7 @@ const {
   hideFooter,
   customTableRowClass,
   customTableDataClass,
+  splitDimensionHeaders,
 } = toRefs(props);
 
 const slots = useSlots();
@@ -293,6 +294,7 @@ const { clientSortOptions, headersForRenderParents, headersForRender, updateSort
   sortBy,
   sortType,
   sortPivotValue,
+  splitDimensionHeaders,
   emits,
 );
 

--- a/src/dev/NestedWithPivotAndTwoValues.vue
+++ b/src/dev/NestedWithPivotAndTwoValues.vue
@@ -8,8 +8,9 @@
     :pivot
     :rows-per-page="-1"
     hide-footer
-    show-index
+    :show-index="false"
     show-index-class="sticky-col"
+    :split-dimension-headers="true"
     locale="en-US"
     @click-cell="alert"
   >
@@ -31,6 +32,7 @@ const dimensions: Dimension[] = [
   {
     text: 'Weeknum',
     value: 'weeknum',
+    cssClass: 'sticky-col',
   },
   {
     text: 'Weekday',

--- a/src/hooks/useHeaders.ts
+++ b/src/hooks/useHeaders.ts
@@ -14,6 +14,7 @@ export default function useHeaders(
   sortBy: Ref<string>,
   sortType: Ref<SortType>,
   sortPivotValue: Ref<string>,
+  splitDimensionHeaders: Ref<boolean>,
   emits: (event: EmitsEventName, ...args: any[]) => void,
 ) {
   const pivotDomain = computed<string[]>(() => {
@@ -121,12 +122,18 @@ export default function useHeaders(
           }
 
           const lastEntry = accumulator[accumulator.length - 1];
-          if (lastEntry && lastEntry.text === text && !lastEntry.isIndex && lastEntry.originalText === originalText) {
+          if (
+            lastEntry &&
+            (item.type === 'tableValue' ? true : !splitDimensionHeaders.value) &&
+            (lastEntry.parent?.text !== null || item.parent?.text !== null) &&
+            lastEntry.text === text &&
+            !lastEntry.isIndex &&
+            lastEntry.originalText === originalText
+          ) {
             // Increment count for subsequent occurrences
             lastEntry.count++;
           } else {
             // Add a new entry for a new or first occurrence
-
             accumulator.push({
               type: 'pivot',
               isIndex: item.value === 'index',
@@ -134,6 +141,7 @@ export default function useHeaders(
               originalText,
               count: 1,
               cssClass: item.cssClass ?? '',
+              parent: item.parent,
             });
           }
 
@@ -146,6 +154,7 @@ export default function useHeaders(
           isIndex: boolean;
           cssClass: string;
           originalText: string | null;
+          parent: { text: string } | undefined;
         }[],
       );
 
@@ -159,7 +168,15 @@ export default function useHeaders(
           const pivotValue = item.pivotValue;
 
           const lastEntry = accumulator[accumulator.length - 1];
-          if (lastEntry && lastEntry.text === text && !lastEntry.isIndex && lastEntry.pivotValue === pivotValue) {
+
+          if (
+            lastEntry &&
+            (item.type === 'tableValue' ? true : !splitDimensionHeaders.value) &&
+            (lastEntry.text !== null || text !== null) &&
+            lastEntry.text === text &&
+            !lastEntry.isIndex &&
+            lastEntry.pivotValue === pivotValue
+          ) {
             // Increment count for subsequent occurrences
             lastEntry.count++;
           } else {

--- a/src/propsWithDefault.ts
+++ b/src/propsWithDefault.ts
@@ -179,4 +179,9 @@ export default {
     default: '-',
     description: 'Text to be shown if cellvalue is null',
   },
+  splitDimensionHeaders: {
+    type: Boolean,
+    default: false,
+    description: 'Forces spit of dimension headers into separate cells.',
+  },
 };

--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -43,6 +43,7 @@ export type Dimension = {
   sortFunc?: any;
   sticky?: boolean;
   cssClass?: string;
+  parent?: { text: string };
   formatFunc?: any;
 };
 


### PR DESCRIPTION
This prop might be useful when you are pivoting and have multiple dimensions and want to make the first column sticky.